### PR TITLE
Add basic XDG_CONFIG_HOME support

### DIFF
--- a/tremc
+++ b/tremc
@@ -3639,9 +3639,18 @@ def show_version(option, opt_str, value, parser):
          (VERSION, TRNSM_VERSION_MIN, TRNSM_VERSION_MAX))
 
 
+def xdg_config_home(*args):
+    p = os.environ.get('XDG_CONFIG_HOME')
+
+    if p is None or not os.path.isabs(p):
+        p = os.path.expanduser('~/.config')
+
+    return os.path.join(p, *args)
+
+
 if __name__ == '__main__':
     # command line parameters
-    default_config_path = os.environ['HOME'] + '/.config/tremc/settings.cfg'
+    default_config_path = xdg_config_home('tremc/settings.cfg')
     parser = OptionParser(usage="%prog [options] [-- transmission-remote options]",
                           description="%%prog %s" % VERSION)
     parser.add_option("-v", "--version", action="callback", callback=show_version,


### PR DESCRIPTION
This patch is mostly just here to remove the hardcoded expansion of
HOME/.config/tremc in favour of simple XDG Base Directory support as I
personally don't use the fall-back defaults.